### PR TITLE
hal: keep VBAT_LDO at 3.3V to preserve RTC during hibernate

### DIFF
--- a/drivers/hal/bf0_hal_pmu.c
+++ b/drivers/hal/bf0_hal_pmu.c
@@ -216,9 +216,10 @@ __HAL_ROM_USED HAL_StatusTypeDef HAL_PMU_RC10Kconfig(void)
 #endif
 
 #ifdef SF32LB52X
-    /* reduce VBAT_LDO output voltage to 3V to avoid leakage current if VCC is lower than 3.3V */
+    /* Keep VBAT_LDO at the 3.3V default so the RTC/AON domain (and therefore
+     * the time) is preserved across hibernate. */
     MODIFY_REG(hwp_pmuc->AON_LDO, PMUC_AON_LDO_VBAT_LDO_SET_VOUT_Msk,
-               MAKE_REG_VAL(0, PMUC_AON_LDO_VBAT_LDO_SET_VOUT_Msk, PMUC_AON_LDO_VBAT_LDO_SET_VOUT_Pos));
+               MAKE_REG_VAL(6, PMUC_AON_LDO_VBAT_LDO_SET_VOUT_Msk, PMUC_AON_LDO_VBAT_LDO_SET_VOUT_Pos));
 
     /* turn off LDO2 to ensure flash changing to 3byte address mode when boot up */
     HAL_PMU_ConfigPeriLdo(PMU_PERI_LDO2_3V3, 0, 1);


### PR DESCRIPTION
Required for https://github.com/coredevices/PebbleOS/pull/1824

## Summary

Ensure the `AON_LDO` / `VBAT_LDO` rail stays at the 3.3 V default when the SF32LB52X SoC enters **hibernate**. This prevents the RTC and `AON` backup domain from losing power, preserving the RTC-clock time across hibernate.

## Motivation

On the `SF32LB52X` platform, lowering `VBAT_LDO` during hibernate causes the `RTC/AON` domain to reset. Keeping the LDO at 3.3 V keeps the RTC alive while the rest of the SoC is powered down, which is required for the PebbleOS hibernate feature.

## Impact

- Only affects `SF32LB52X` builds (`#ifdef SF32LB52X`).
- Only touches the hibernate and shutdown entry paths.
- `HAL_PMU_EnterHibernate()` is used by the PebbleOS hibernate feature.
- No impact on normal runtime, sleep modes, or other SoC families.